### PR TITLE
Add bind_host to allow listening on other IPs

### DIFF
--- a/dwarf/compute/api.py
+++ b/dwarf/compute/api.py
@@ -207,7 +207,7 @@ class _ComputeApiServer(api_server.ApiServer):
 
     def __init__(self):
         super(_ComputeApiServer, self).__init__('Compute',
-                                                '127.0.0.1',
+                                                CONF.bind_host,
                                                 CONF.compute_api_port)
 
         self.app.route('/v1.1/<dummy_tenant_id>/images/<image_id>',

--- a/dwarf/config.py
+++ b/dwarf/config.py
@@ -41,6 +41,7 @@ _DEFAULT_CONFIG = {
     'libvirt_bridge_name': 'dwbr0',
     'libvirt_bridge_ip': '10.10.10.1',
 
+    'bind_host': '127.0.0.1',
     'identity_api_port': 35357,
     'compute_api_port': 8774,
     'image_api_port': 9292,

--- a/dwarf/identity/api.py
+++ b/dwarf/identity/api.py
@@ -48,11 +48,20 @@ SERVICE_COMPUTE = {
     "type": "compute",
     "endpoints": [{
         "tenantId": "1000",
-        "publicURL": "http://127.0.0.1:%s/v1.1/1000" % CONF.compute_api_port,
+        "publicURL": "http://%s:%s/v1.1/1000" % (
+            CONF.bind_host,
+            CONF.compute_api_port,
+        ),
         "region": "dwarf-region",
         "versionId": "1.1",
-        "versionInfo": "http://127.0.0.1:%s/v1.1" % CONF.compute_api_port,
-        "versionList": "http://127.0.0.1:%s" % CONF.compute_api_port
+        "versionInfo": "http://%s:%s/v1.1" % (
+            CONF.bind_host,
+            CONF.compute_api_port,
+        ),
+        "versionList": "http://%s:%s" % (
+            CONF.bind_host,
+            CONF.compute_api_port,
+        )
     }]
 }
 
@@ -61,11 +70,20 @@ SERVICE_IMAGE = {
     "type": "image",
     "endpoints": [{
         "tenantId": "1000",
-        "publicURL": "http://127.0.0.1:%s/v1.0" % CONF.image_api_port,
+        "publicURL": "http://%s:%s/v1.0" % (
+            CONF.bind_host,
+            CONF.image_api_port,
+        ),
         "region": "dwarf-region",
         "versionId": "1.0",
-        "versionInfo": "http://127.0.0.1:%s/v1.0" % CONF.image_api_port,
-        "versionList": "http://127.0.0.1:%s" % CONF.image_api_port
+        "versionInfo": "http://%s:%s/v1.0" % (
+            CONF.bind_host,
+            CONF.image_api_port,
+        ),
+        "versionList": "http://%s:%s" % (
+            CONF.bind_host,
+            CONF.image_api_port,
+        )
     }]
 }
 
@@ -97,7 +115,7 @@ def _route_tokens():
 class _IdentityApiServer(api_server.ApiServer):
     def __init__(self):
         super(_IdentityApiServer, self).__init__('Identity',
-                                                 '127.0.0.1',
+                                                 CONF.bind_host,
                                                  CONF.identity_api_port)
 
         self.app.route('/v2.0/tokens',

--- a/dwarf/image/api.py
+++ b/dwarf/image/api.py
@@ -161,7 +161,7 @@ def _route_images():
 class _ImageApiServer(api_server.ApiServer):
     def __init__(self):
         super(_ImageApiServer, self).__init__('Image',
-                                              '127.0.0.1',
+                                              CONF.bind_host,
                                               CONF.image_api_port)
 
         self.app.route(('/v1/images/<image_id>', '//v1/images/<image_id>'),

--- a/etc/dwarf.conf
+++ b/etc/dwarf.conf
@@ -8,6 +8,9 @@ libvirt_domain_type: kvm
 libvirt_bridge_name: dwbr0
 libvirt_bridge_ip: 10.10.10.1
 
+# Bind to this IP
+bind_host: 127.0.0.1
+
 # Port numbers for the different OpenStack services
 identity_api_port: 35357
 compute_api_port: 8774


### PR DESCRIPTION
Bind to the original 127.0.0.1 by default but allow living on the
edge and binding to another host IP.