### PR TITLE
Make network name configurable

### DIFF
--- a/dwarf/compute/libvirt-net.xml
+++ b/dwarf/compute/libvirt-net.xml
@@ -1,5 +1,5 @@
 <network>
-    <name>dwarf</name>
+    <name>${network_name}</name>
     <uuid>${uuid}</uuid>
     <forward mode='nat'>
         <nat>

--- a/dwarf/compute/virt.py
+++ b/dwarf/compute/virt.py
@@ -118,6 +118,7 @@ def _create_net_xml():
 
     xml_info = {
         'uuid': str(uuid.uuid4()),
+        'network_name': CONF.libvirt_network_name,
         'bridge': CONF.libvirt_bridge_name,
         'ip': CONF.libvirt_bridge_ip,
         'dhcp_start': '.'.join(CONF.libvirt_bridge_ip.split('.')[0:3] + ['2']),
@@ -303,7 +304,7 @@ class Controller(object):
         self._connect()
         try:
             # Check if the network already exists
-            net = self.libvirt.networkLookupByName('dwarf')
+            net = self.libvirt.networkLookupByName(CONF.libvirt_network_name)
         except libvirt.libvirtError as e:
             if e.get_error_code() != libvirt.VIR_ERR_NO_NETWORK:
                 # Unexpected error
@@ -325,7 +326,7 @@ class Controller(object):
         """
         LOG.info('get_dhcp_lease(server=%s)', server)
 
-        net = self.libvirt.networkLookupByName('dwarf')
+        net = self.libvirt.networkLookupByName(CONF.libvirt_network_name)
         lease = net.DHCPLeases(mac=server['mac_address'])
         if len(lease) == 1:
             return {'ip': lease[0]['ipaddr']}

--- a/dwarf/config.py
+++ b/dwarf/config.py
@@ -40,6 +40,7 @@ _DEFAULT_CONFIG = {
     'libvirt_domain_type': 'kvm',
     'libvirt_bridge_name': 'dwbr0',
     'libvirt_bridge_ip': '10.0.0.1',
+    'libvirt_network_name': 'dwarf',
 
     'bind_host': '127.0.0.1',
     'bind_port': 5000,

--- a/etc/dwarf.conf
+++ b/etc/dwarf.conf
@@ -7,6 +7,7 @@ debug: true
 libvirt_domain_type: kvm
 libvirt_bridge_name: dwbr0
 libvirt_bridge_ip: 10.0.0.1
+libvirt_network_name: dwarf
 
 # Bind to this IP and port
 bind_host: 127.0.0.1


### PR DESCRIPTION
Add config option 'libvirt_network_name'.

Defaults to 'dwarf', but this lets us use libvirt's 'default' if necessary.

Signed-off-by: Dean Troyer <dtroyer@gmail.com>