### PR TITLE
Add support for flavor extra_specs

### DIFF
--- a/dwarf/compute/api.py
+++ b/dwarf/compute/api.py
@@ -67,6 +67,18 @@ def _route_version():
 # Bottle Flavors API routes
 
 @exception.catchall
+def _route_flavors_id_extra(flavor_id):
+    """
+    Route:  /compute/v2.0/flavors/<flavor_id>/os-extra_specs
+    Method: GET
+    """
+    utils.show_request(bottle.request)
+
+    # nova flavor-show <flavor_id>
+    return api_response.show_flavor_extra(FLAVORS.show(flavor_id))
+
+
+@exception.catchall
 def _route_flavors_id(flavor_id):
     """
     Route:  /compute/v2.0/flavors/<flavor_id>
@@ -240,6 +252,9 @@ def set_routes(app):
     app.route('/compute/v2.0/servers/<server_id>/action',
               method='POST',
               callback=_route_servers_id_action)
+    app.route('/compute/v2.0/flavors/<flavor_id>/os-extra_specs',
+              method=('GET'),
+              callback=_route_flavors_id_extra)
     app.route('/compute/v2.0/flavors/<flavor_id>',
               method=('GET', 'DELETE'),
               callback=_route_flavors_id)

--- a/dwarf/compute/api_response.py
+++ b/dwarf/compute/api_response.py
@@ -67,6 +67,10 @@ FLAVOR = """{
     "name": "{{name}}"
 }"""
 
+FLAVOR_EXTRA = """{
+    "extra_specs": {}
+}"""
+
 
 def create_flavor(data):
     return {'flavor': utils.json_render(FLAVOR, data, _details=True)}
@@ -79,6 +83,10 @@ def list_flavors(data, details=True):
 
 def show_flavor(data):
     return {'flavor': utils.json_render(FLAVOR, data, _details=True)}
+
+
+def show_flavor_extra(data):
+    return {'extra_specs': utils.json_render(FLAVOR_EXTRA, data)}
 
 
 # -----------------------------------------------------------------------------

--- a/tests/api/test_compute_flavors.py
+++ b/tests/api/test_compute_flavors.py
@@ -56,6 +56,11 @@ FLAVOR_RESP = """{
 }"""
 
 
+FLAVOR_EXTRA_RESP = """{
+    "extra_specs": {}
+}"""
+
+
 def list_flavors_resp(flavor, details=False):
     return {'flavors': [utils.json_render(FLAVOR_RESP, f, _details=details)
                         for f in flavor]}
@@ -63,6 +68,10 @@ def list_flavors_resp(flavor, details=False):
 
 def show_flavor_resp(flavor):
     return {'flavor': utils.json_render(FLAVOR_RESP, flavor, _details=True)}
+
+
+def show_flavor_extra_resp(flavor):
+    return {'flavor': utils.json_render(FLAVOR_REXTRA_ESP, flavor)}
 
 
 def create_flavor_resp(flavor):
@@ -99,6 +108,11 @@ class DwarfTestCase(utils.TestCase):
     def test_show_flavor(self):
         resp = self.app.get('/compute/v2.0/flavors/%s' % flavor1['id'],
                             status=200)
+        self.assertEqual(json.loads(resp.body), show_flavor_resp(flavor1))
+
+    def test_show_flavor_extra(self):
+        resp = self.app.get('/compute/v2.0/flavors/%s/os-extra_specs' %
+                            flavor1['id'], status=200)
         self.assertEqual(json.loads(resp.body), show_flavor_resp(flavor1))
 
     def test_delete_flavor(self):


### PR DESCRIPTION
Add a stub route for /compute/flavor/.../ os-extra_specs

Signed-off-by: Dean Troyer <dtroyer@gmail.com>