### PR TITLE
Add metadata key to GET /server response

### DIFF
--- a/dwarf/compute/api_response.py
+++ b/dwarf/compute/api_response.py
@@ -154,7 +154,8 @@ SERVER = """{
     },
     "key_name": "{{key_name}}",
     "name": "{{name}}",
-    "status": "{{status}}"
+    "status": "{{status}}",
+    "metadata": {}
 }"""
 
 

--- a/tests/api/test_compute_servers.py
+++ b/tests/api/test_compute_servers.py
@@ -72,6 +72,7 @@ SERVER_RESP = """{
         "key_name": "None",
         "name": "Test server 1",
         "status": "building",
+        "metadata": {},
         "updated_at": "2001-02-03 04:05:06"
     }
 }"""


### PR DESCRIPTION
The metadata key is still present for backward-compatibility.

Signed-off-by: Dean Troyer <dtroyer@gmail.com>